### PR TITLE
Fix erroneous comparison of hosts during URI matching

### DIFF
--- a/library/src/main/java/dev/gerlot/securewebview/SecureWebView.java
+++ b/library/src/main/java/dev/gerlot/securewebview/SecureWebView.java
@@ -98,7 +98,7 @@ public class SecureWebView extends FrameLayout {
                     return authoritiesEqual && (pathEqual || (this.uri.getPath() == null && uri.getPath() == null));
                 }
                 case AUTHORITY_CONTAIN -> { return uri.getAuthority() != null && this.uri.getAuthority() != null && uri.getAuthority().contains(this.uri.getAuthority()); }
-                case HOST -> { return this.uri.getHost() != null && this.uri.getHost().equals(this.uri.getHost()); }
+                case HOST -> { return uri.getHost() != null && uri.getHost().equals(this.uri.getHost()); }
                 case BEGINNING -> { return uri.toString().startsWith(this.uri.toString());  }
                 default -> { return false; }
             }


### PR DESCRIPTION
Fixes #2 by comparing the URI parameter's host against the member URI's host.